### PR TITLE
feat: allow `declare const` to be used for brand symbol declarations

### DIFF
--- a/src/components/Generator.tsx
+++ b/src/components/Generator.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button';
+import { usePreferredSymbolStyle } from '@/hooks/usePreferredSymbolStyle';
 import { generateBrandedTypes } from '@/lib/generateBrandedTypes';
 import { useState } from 'react';
 import { Textarea } from './ui/textarea';
@@ -9,9 +10,13 @@ id, number`);
   const [outputText, setOutputText] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
 
+  const [preferDeclareConst, setPreferDeclareConst] = usePreferredSymbolStyle();
+
   function handleGenerate() {
     try {
-      const result = generateBrandedTypes(inputText);
+      const result = generateBrandedTypes(inputText, {
+        useDeclareConst: preferDeclareConst,
+      });
       setOutputText(result);
       setErrorMessage('');
     } catch (error) {
@@ -35,7 +40,17 @@ id, number`);
         placeholder='Please input data in CSV or Tab separated format'
         aria-label='Input Text'
       />
-      <Button onClick={handleGenerate}>Generate</Button>
+      <div className='flex items-center gap-4 my-2'>
+        <Button onClick={handleGenerate}>Generate</Button>
+        <label className='flex items-center gap-2 text-sm cursor-pointer'>
+          <input
+            type='checkbox'
+            checked={preferDeclareConst}
+            onChange={(e) => setPreferDeclareConst(e.target.checked)}
+          />
+          Use <code>declare const</code> for brand symbol
+        </label>
+      </div>
       {errorMessage && <p className='text-red-600 font-semibold mb-4'>{errorMessage}</p>}
       <h1 className='text-xl font-bold mb-2'>Output</h1>
       <p>

--- a/src/hooks/usePreferredSymbolStyle.ts
+++ b/src/hooks/usePreferredSymbolStyle.ts
@@ -1,0 +1,36 @@
+import { useCallback, useSyncExternalStore } from 'react';
+
+export const usePreferredSymbolStyle = () => {
+  const useDeclareConst = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  const setUseDeclareConst = useCallback((value: boolean) => {
+    localStorage.setItem(storageKey, JSON.stringify(value));
+    window.dispatchEvent(new CustomEvent(eventName));
+  }, []);
+
+  return [useDeclareConst, setUseDeclareConst] as const;
+};
+
+declare global {
+  interface WindowEventMap {
+    'branded-type-generator:symbolStyleChanged': CustomEvent;
+  }
+}
+
+const eventName = 'branded-type-generator:symbolStyleChanged' satisfies keyof WindowEventMap;
+const storageKey = 'preferredSymbolStyle';
+
+function subscribe(onStoreChange: () => void) {
+  window.addEventListener(eventName, onStoreChange);
+  return () => window.removeEventListener(eventName, onStoreChange);
+}
+
+function getSnapshot(): boolean {
+  const stored = localStorage.getItem(storageKey);
+  const parsed = JSON.parse(stored ?? 'false');
+  return typeof parsed === 'boolean' ? parsed : false;
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}

--- a/src/lib/generateBrandedTypes.ts
+++ b/src/lib/generateBrandedTypes.ts
@@ -1,9 +1,19 @@
+type TypeGenerationPreferences = {
+  /**
+   * Set `true` to use `declare const fooBrand: unique symbol;` to remove the symbol from runtime code.
+   */
+  useDeclareConst: boolean;
+};
+
 /**
  * BrandedType生成関数
  * @param input 入力テキスト (CSV または タブ区切り)
  * @returns BrandedTypeのコードを文字列で返す
  */
-export function generateBrandedTypes(input: string): string {
+export function generateBrandedTypes(
+  input: string,
+  preferences: TypeGenerationPreferences,
+): string {
   const lines = input
     .split('\n')
     .map((line) => line.trim())
@@ -27,9 +37,13 @@ export function generateBrandedTypes(input: string): string {
     const camelCaseName = name.charAt(0).toUpperCase() + name.slice(1);
     const brand = `${name}Brand`;
 
+    const brandSymbol = preferences.useDeclareConst
+      ? `declare const ${brand}: unique symbol;`
+      : `const ${brand} = Symbol();`;
+
     output.push(
       `
-const ${brand} = Symbol();
+${brandSymbol}
 
 export type ${camelCaseName} = ${type} & { [${brand}]: unknown };
 

--- a/src/tests/Generator.test.tsx
+++ b/src/tests/Generator.test.tsx
@@ -32,6 +32,30 @@ describe('Generator.tsx tests', () => {
     expect(outputValue).toContain('return p as Name;');
   });
 
+  test('`Use declare const for brand symbol` を有効にしたときに、Symbol が `declare const` で宣言されること', async () => {
+    const user = userEvent.setup();
+    render(<Generator />);
+
+    // `declare const` を使用するオプションを有効にする
+    const checkbox = screen.getByRole('checkbox', { name: /Use declare const for brand symbol/i });
+    await user.click(checkbox);
+
+    // テキストエリアをクリアして新しい内容を入力
+    const inputTextarea = screen.getByLabelText('Input Text');
+    await user.clear(inputTextarea);
+    await user.type(inputTextarea, 'id, number');
+
+    // 生成ボタンをクリック
+    const button = screen.getByRole('button', { name: 'Generate' });
+    await user.click(button);
+
+    // 出力テキストエリアに `declare const` が含まれていることを確認
+    const outputTextarea = screen.getByLabelText<HTMLTextAreaElement>('Output Text');
+    const outputValue = outputTextarea.value;
+
+    expect(outputValue).toContain('declare const idBrand: unique symbol;');
+  });
+
   test('不正な形式で入力されたときにエラーメッセージが表示されること', async () => {
     const user = userEvent.setup();
     render(<Generator />);


### PR DESCRIPTION
> [!NOTE]
> コミットごとにレビューいただいたほうが見やすいです。

Branded Types Generator が参考にした記事にもありますが、ランタイムコードに brand symbol を残さないために `declare const s: unique symbol;` のようなコードを使うことができます。
https://qiita.com/uhyo/items/de4cb2085fdbdf484b83#declare-const%E3%82%92%E4%BD%BF%E3%81%86%E6%96%B9%E6%B3%95

この PR では、ユーザーがコードを生成するときに`declare const` を使って symbol を宣言するか選べるようにします。
デフォルトでは、今まで通り `const sym = Symbol();` を利用します。
設定は localStorage に保存されるので 1 度設定すると以降は最初から設定が読み込まれます。


<img width="821" height="582" alt="スクリーンショット 2026-05-21 22 38 49" src="https://github.com/user-attachments/assets/5c43a9c1-8eec-4ac1-8987-5acd00127adf" />
